### PR TITLE
docs(readme): update usage versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ jobs:
   size:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: antfu/export-size-action@v1
+      - uses: actions/checkout@v2
+      - uses: antfu/export-size-action@v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -37,7 +37,7 @@ jobs:
 #### Monorepo
 
 ```yaml
-  - uses: antfu/export-size-action@v1
+  - uses: antfu/export-size-action@v1.0.0
     with:
       github_token: ${{ secrets.GITHUB_TOKEN }}
       paths: package/core,package/foo

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
 #### Monorepo
 
 ```yaml
-  - uses: antfu/export-size-action@v1.0.0
+  - uses: antfu/export-size-action@v1
     with:
       github_token: ${{ secrets.GITHUB_TOKEN }}
       paths: package/core,package/foo

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: antfu/export-size-action@v1.0.0
+      - uses: antfu/export-size-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
- [`actions/checkout`](https://github.com/marketplace/actions/checkout) was outdated
- Referencing `antfu/export-size-action@v1` [failed for me](https://github.com/privatenumber/vue-v/pull/7/checks?check_run_id=1421368607). I'm not sure if you want to fix the tagging, but for now, I've updated the docs to reflect what the [Marketplace page](https://github.com/marketplace/actions/export-size-action) tells me to use